### PR TITLE
Add probot-app-deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "probot": "3.0.2",
+    "probot-app-deploy": "^1.0.0",
     "probot-app-label-release-pr": "1.0.4",
     "probot-app-license": "1.0.0",
     "probot-app-merge-pr": "1.0.2",
@@ -19,6 +20,7 @@
   },
   "probot": {
     "apps": [
+      "probot-app-deploy",
       "probot-app-label-release-pr",
       "probot-app-merge-pr",
       "probot-app-migrations",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,6 +3,6 @@
 set -ex
 
 yarn global add now@9.0.0-canary.6 now-replace
-APP_URL=$(now -t $NOW_TOKEN --public -e PRIVATE_KEY=@private-key -e APP_ID=@app-id -e WEBHOOK_SECRET=@webhook-secret -e NODE_ENV="production")
+APP_URL=$(now -t $NOW_TOKEN --public -e PRIVATE_KEY=@private-key -e APP_ID=@app-id -e BUILDKITE_TOKEN=@buildkite-token -e WEBHOOK_SECRET=@webhook-secret -e NODE_ENV="production")
 now scale $APP_URL 1 -t $NOW_TOKEN
 now-replace fusion-probot $APP_URL -t $NOW_TOKEN

--- a/yarn.lock
+++ b/yarn.lock
@@ -2307,6 +2307,12 @@ private@^0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
+probot-app-deploy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/probot-app-deploy/-/probot-app-deploy-1.0.0.tgz#3d91320aa31e98b9c4ba42b35976dd212c890314"
+  dependencies:
+    probot "^3.0.0"
+
 probot-app-label-release-pr@1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/probot-app-label-release-pr/-/probot-app-label-release-pr-1.0.4.tgz#0cf915b85f55c847bf040d86bcdc307163fcc7dd"


### PR DESCRIPTION
This will add a probot which will trigger a npm deploy pipeline inside of Buildkite. Before deploying we will need to set the BUILDKITE_TOKEN env var.

This will currently attempt to publish a second time for packages already being published by travis, but it should just silently fail due to the package versions being the same.

The repo for this package is here: https://github.com/fusionjs-meta/probot-app-deploy