### PR TITLE
Update release verification builds status to pending

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "transform": {
       "^.+\\.jsx?$": "babel-jest"
     },
-    "testRegex": "src/.*__tests__/.*.test.js"
+    "testRegex": "src/.*__tests__/.*.test.js$"
   }
 }

--- a/src/__tests__/__snapshots__/buildkite-meta-data.test.js.snap
+++ b/src/__tests__/__snapshots__/buildkite-meta-data.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildkite meta-data populates meta-data with branch information 1`] = `
+Object {
+  "author": Object {
+    "name": "KevinGrandon",
+  },
+  "branch": "master",
+  "commit": "HEAD",
+  "message": "probot-playground, Release v1.0.7 - release verification",
+  "meta_data": Object {
+    "release-pr-base-repo-full-name": "KevinGrandon/probot-playground",
+    "release-pr-head-repo-full-name": "KevinGrandon/probot-playground",
+    "release-pr-head-sha": "23999b445a8daf81238dbcdc08776f4489f4aa98",
+    "release-pr-number": "6",
+    "release-pr-prerelease": "false",
+  },
+}
+`;

--- a/src/__tests__/buildkite-meta-data.test.js
+++ b/src/__tests__/buildkite-meta-data.test.js
@@ -1,0 +1,43 @@
+import {createRobot} from 'probot';
+import app from '../release-verification';
+
+import releasePayload from './fixtures/release-payload.json';
+
+jest.mock('child_process', () => {
+  return {
+    exec: jest.fn(),
+  };
+});
+
+const mockedExec = require('child_process').exec;
+
+describe('buildkite meta-data', () => {
+  let robot;
+  let github;
+
+  beforeEach(() => {
+    robot = createRobot();
+    app(robot);
+    github = {
+      issues: {
+        createComment: jest.fn(),
+      },
+      repos: {
+        createStatus: jest.fn().mockReturnValue(Promise.resolve(true)),
+      },
+    };
+    // Passes the mocked out GitHub API into out robot instance
+    robot.auth = () => Promise.resolve(github);
+  });
+
+  it('populates meta-data with branch information', async () => {
+    await robot.receive({
+      event: 'pull_request',
+      payload: releasePayload,
+    });
+    const jsonData = JSON.parse(
+      mockedExec.mock.calls[0][0].match(/\-d\ \'([^']*)'/)[1]
+    );
+    expect(jsonData).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/fixtures/prerelease-payload.json
+++ b/src/__tests__/fixtures/prerelease-payload.json
@@ -1,0 +1,619 @@
+{
+  "action": "labeled",
+  "number": 6,
+  "pull_request": {
+    "url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/6",
+    "id": 171108087,
+    "html_url": "https://github.com/KevinGrandon/probot-playground/pull/6",
+    "diff_url": "https://github.com/KevinGrandon/probot-playground/pull/6.diff",
+    "patch_url":
+      "https://github.com/KevinGrandon/probot-playground/pull/6.patch",
+    "issue_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/issues/6",
+    "number": 6,
+    "state": "open",
+    "locked": false,
+    "title": "Release v1.0.7-alpha1",
+    "user": {
+      "login": "KevinGrandon",
+      "id": 122602,
+      "avatar_url": "https://avatars0.githubusercontent.com/u/122602?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/KevinGrandon",
+      "html_url": "https://github.com/KevinGrandon",
+      "followers_url": "https://api.github.com/users/KevinGrandon/followers",
+      "following_url":
+        "https://api.github.com/users/KevinGrandon/following{/other_user}",
+      "gists_url": "https://api.github.com/users/KevinGrandon/gists{/gist_id}",
+      "starred_url":
+        "https://api.github.com/users/KevinGrandon/starred{/owner}{/repo}",
+      "subscriptions_url":
+        "https://api.github.com/users/KevinGrandon/subscriptions",
+      "organizations_url": "https://api.github.com/users/KevinGrandon/orgs",
+      "repos_url": "https://api.github.com/users/KevinGrandon/repos",
+      "events_url":
+        "https://api.github.com/users/KevinGrandon/events{/privacy}",
+      "received_events_url":
+        "https://api.github.com/users/KevinGrandon/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "created_at": "2018-02-23T20:24:20Z",
+    "updated_at": "2018-02-23T20:24:25Z",
+    "closed_at": null,
+    "merged_at": null,
+    "merge_commit_sha": "d8df0413d0579f10fdb571e681833828e803698a",
+    "assignee": null,
+    "assignees": [],
+    "requested_reviewers": [],
+    "requested_teams": [],
+    "labels": [
+      {
+        "id": 742557442,
+        "url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/labels/release",
+        "name": "release",
+        "color": "bfc7fc",
+        "default": false
+      }
+    ],
+    "milestone": null,
+    "commits_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/6/commits",
+    "review_comments_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/6/comments",
+    "review_comment_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/comments{/number}",
+    "comments_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/issues/6/comments",
+    "statuses_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/statuses/23999b445a8daf81238dbcdc08776f4489f4aa98",
+    "head": {
+      "label": "KevinGrandon:test-release2",
+      "ref": "test-release2",
+      "sha": "23999b445a8daf81238dbcdc08776f4489f4aa98",
+      "user": {
+        "login": "KevinGrandon",
+        "id": 122602,
+        "avatar_url": "https://avatars0.githubusercontent.com/u/122602?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/KevinGrandon",
+        "html_url": "https://github.com/KevinGrandon",
+        "followers_url": "https://api.github.com/users/KevinGrandon/followers",
+        "following_url":
+          "https://api.github.com/users/KevinGrandon/following{/other_user}",
+        "gists_url":
+          "https://api.github.com/users/KevinGrandon/gists{/gist_id}",
+        "starred_url":
+          "https://api.github.com/users/KevinGrandon/starred{/owner}{/repo}",
+        "subscriptions_url":
+          "https://api.github.com/users/KevinGrandon/subscriptions",
+        "organizations_url": "https://api.github.com/users/KevinGrandon/orgs",
+        "repos_url": "https://api.github.com/users/KevinGrandon/repos",
+        "events_url":
+          "https://api.github.com/users/KevinGrandon/events{/privacy}",
+        "received_events_url":
+          "https://api.github.com/users/KevinGrandon/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "repo": {
+        "id": 109757823,
+        "name": "probot-playground",
+        "full_name": "KevinGrandon/probot-playground",
+        "owner": {
+          "login": "KevinGrandon",
+          "id": 122602,
+          "avatar_url": "https://avatars0.githubusercontent.com/u/122602?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/KevinGrandon",
+          "html_url": "https://github.com/KevinGrandon",
+          "followers_url":
+            "https://api.github.com/users/KevinGrandon/followers",
+          "following_url":
+            "https://api.github.com/users/KevinGrandon/following{/other_user}",
+          "gists_url":
+            "https://api.github.com/users/KevinGrandon/gists{/gist_id}",
+          "starred_url":
+            "https://api.github.com/users/KevinGrandon/starred{/owner}{/repo}",
+          "subscriptions_url":
+            "https://api.github.com/users/KevinGrandon/subscriptions",
+          "organizations_url": "https://api.github.com/users/KevinGrandon/orgs",
+          "repos_url": "https://api.github.com/users/KevinGrandon/repos",
+          "events_url":
+            "https://api.github.com/users/KevinGrandon/events{/privacy}",
+          "received_events_url":
+            "https://api.github.com/users/KevinGrandon/received_events",
+          "type": "User",
+          "site_admin": false
+        },
+        "private": false,
+        "html_url": "https://github.com/KevinGrandon/probot-playground",
+        "description": "Test repo to play /w probot.",
+        "fork": false,
+        "url": "https://api.github.com/repos/KevinGrandon/probot-playground",
+        "forks_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/forks",
+        "keys_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/keys{/key_id}",
+        "collaborators_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/collaborators{/collaborator}",
+        "teams_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/teams",
+        "hooks_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/hooks",
+        "issue_events_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues/events{/number}",
+        "events_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/events",
+        "assignees_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/assignees{/user}",
+        "branches_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/branches{/branch}",
+        "tags_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/tags",
+        "blobs_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/blobs{/sha}",
+        "git_tags_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/tags{/sha}",
+        "git_refs_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/refs{/sha}",
+        "trees_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/trees{/sha}",
+        "statuses_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/statuses/{sha}",
+        "languages_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/languages",
+        "stargazers_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/stargazers",
+        "contributors_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/contributors",
+        "subscribers_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/subscribers",
+        "subscription_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/subscription",
+        "commits_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/commits{/sha}",
+        "git_commits_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/commits{/sha}",
+        "comments_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/comments{/number}",
+        "issue_comment_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues/comments{/number}",
+        "contents_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/contents/{+path}",
+        "compare_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/compare/{base}...{head}",
+        "merges_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/merges",
+        "archive_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/{archive_format}{/ref}",
+        "downloads_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/downloads",
+        "issues_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues{/number}",
+        "pulls_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/pulls{/number}",
+        "milestones_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/milestones{/number}",
+        "notifications_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/notifications{?since,all,participating}",
+        "labels_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/labels{/name}",
+        "releases_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/releases{/id}",
+        "deployments_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/deployments",
+        "created_at": "2017-11-06T22:32:54Z",
+        "updated_at": "2017-11-06T22:32:54Z",
+        "pushed_at": "2018-02-23T20:24:21Z",
+        "git_url": "git://github.com/KevinGrandon/probot-playground.git",
+        "ssh_url": "git@github.com:KevinGrandon/probot-playground.git",
+        "clone_url": "https://github.com/KevinGrandon/probot-playground.git",
+        "svn_url": "https://github.com/KevinGrandon/probot-playground",
+        "homepage": null,
+        "size": 5,
+        "stargazers_count": 0,
+        "watchers_count": 0,
+        "language": null,
+        "has_issues": true,
+        "has_projects": true,
+        "has_downloads": true,
+        "has_wiki": true,
+        "has_pages": false,
+        "forks_count": 0,
+        "mirror_url": null,
+        "archived": false,
+        "open_issues_count": 2,
+        "license": null,
+        "forks": 0,
+        "open_issues": 2,
+        "watchers": 0,
+        "default_branch": "master"
+      }
+    },
+    "base": {
+      "label": "KevinGrandon:master",
+      "ref": "master",
+      "sha": "eaf7120fd50a3805c64fe83ee3b14b2ae48ab517",
+      "user": {
+        "login": "KevinGrandon",
+        "id": 122602,
+        "avatar_url": "https://avatars0.githubusercontent.com/u/122602?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/KevinGrandon",
+        "html_url": "https://github.com/KevinGrandon",
+        "followers_url": "https://api.github.com/users/KevinGrandon/followers",
+        "following_url":
+          "https://api.github.com/users/KevinGrandon/following{/other_user}",
+        "gists_url":
+          "https://api.github.com/users/KevinGrandon/gists{/gist_id}",
+        "starred_url":
+          "https://api.github.com/users/KevinGrandon/starred{/owner}{/repo}",
+        "subscriptions_url":
+          "https://api.github.com/users/KevinGrandon/subscriptions",
+        "organizations_url": "https://api.github.com/users/KevinGrandon/orgs",
+        "repos_url": "https://api.github.com/users/KevinGrandon/repos",
+        "events_url":
+          "https://api.github.com/users/KevinGrandon/events{/privacy}",
+        "received_events_url":
+          "https://api.github.com/users/KevinGrandon/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "repo": {
+        "id": 109757823,
+        "name": "probot-playground",
+        "full_name": "KevinGrandon/probot-playground",
+        "owner": {
+          "login": "KevinGrandon",
+          "id": 122602,
+          "avatar_url": "https://avatars0.githubusercontent.com/u/122602?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/KevinGrandon",
+          "html_url": "https://github.com/KevinGrandon",
+          "followers_url":
+            "https://api.github.com/users/KevinGrandon/followers",
+          "following_url":
+            "https://api.github.com/users/KevinGrandon/following{/other_user}",
+          "gists_url":
+            "https://api.github.com/users/KevinGrandon/gists{/gist_id}",
+          "starred_url":
+            "https://api.github.com/users/KevinGrandon/starred{/owner}{/repo}",
+          "subscriptions_url":
+            "https://api.github.com/users/KevinGrandon/subscriptions",
+          "organizations_url": "https://api.github.com/users/KevinGrandon/orgs",
+          "repos_url": "https://api.github.com/users/KevinGrandon/repos",
+          "events_url":
+            "https://api.github.com/users/KevinGrandon/events{/privacy}",
+          "received_events_url":
+            "https://api.github.com/users/KevinGrandon/received_events",
+          "type": "User",
+          "site_admin": false
+        },
+        "private": false,
+        "html_url": "https://github.com/KevinGrandon/probot-playground",
+        "description": "Test repo to play /w probot.",
+        "fork": false,
+        "url": "https://api.github.com/repos/KevinGrandon/probot-playground",
+        "forks_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/forks",
+        "keys_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/keys{/key_id}",
+        "collaborators_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/collaborators{/collaborator}",
+        "teams_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/teams",
+        "hooks_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/hooks",
+        "issue_events_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues/events{/number}",
+        "events_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/events",
+        "assignees_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/assignees{/user}",
+        "branches_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/branches{/branch}",
+        "tags_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/tags",
+        "blobs_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/blobs{/sha}",
+        "git_tags_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/tags{/sha}",
+        "git_refs_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/refs{/sha}",
+        "trees_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/trees{/sha}",
+        "statuses_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/statuses/{sha}",
+        "languages_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/languages",
+        "stargazers_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/stargazers",
+        "contributors_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/contributors",
+        "subscribers_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/subscribers",
+        "subscription_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/subscription",
+        "commits_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/commits{/sha}",
+        "git_commits_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/commits{/sha}",
+        "comments_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/comments{/number}",
+        "issue_comment_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues/comments{/number}",
+        "contents_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/contents/{+path}",
+        "compare_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/compare/{base}...{head}",
+        "merges_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/merges",
+        "archive_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/{archive_format}{/ref}",
+        "downloads_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/downloads",
+        "issues_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues{/number}",
+        "pulls_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/pulls{/number}",
+        "milestones_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/milestones{/number}",
+        "notifications_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/notifications{?since,all,participating}",
+        "labels_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/labels{/name}",
+        "releases_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/releases{/id}",
+        "deployments_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/deployments",
+        "created_at": "2017-11-06T22:32:54Z",
+        "updated_at": "2017-11-06T22:32:54Z",
+        "pushed_at": "2018-02-23T20:24:21Z",
+        "git_url": "git://github.com/KevinGrandon/probot-playground.git",
+        "ssh_url": "git@github.com:KevinGrandon/probot-playground.git",
+        "clone_url": "https://github.com/KevinGrandon/probot-playground.git",
+        "svn_url": "https://github.com/KevinGrandon/probot-playground",
+        "homepage": null,
+        "size": 5,
+        "stargazers_count": 0,
+        "watchers_count": 0,
+        "language": null,
+        "has_issues": true,
+        "has_projects": true,
+        "has_downloads": true,
+        "has_wiki": true,
+        "has_pages": false,
+        "forks_count": 0,
+        "mirror_url": null,
+        "archived": false,
+        "open_issues_count": 2,
+        "license": null,
+        "forks": 0,
+        "open_issues": 2,
+        "watchers": 0,
+        "default_branch": "master"
+      }
+    },
+    "_links": {
+      "self": {
+        "href":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/6"
+      },
+      "html": {
+        "href": "https://github.com/KevinGrandon/probot-playground/pull/6"
+      },
+      "issue": {
+        "href":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues/6"
+      },
+      "comments": {
+        "href":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues/6/comments"
+      },
+      "review_comments": {
+        "href":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/6/comments"
+      },
+      "review_comment": {
+        "href":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/comments{/number}"
+      },
+      "commits": {
+        "href":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/6/commits"
+      },
+      "statuses": {
+        "href":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/statuses/23999b445a8daf81238dbcdc08776f4489f4aa98"
+      }
+    },
+    "author_association": "OWNER",
+    "merged": false,
+    "mergeable": true,
+    "rebaseable": true,
+    "mergeable_state": "unstable",
+    "merged_by": null,
+    "comments": 0,
+    "review_comments": 0,
+    "maintainer_can_modify": false,
+    "commits": 1,
+    "additions": 3,
+    "deletions": 3,
+    "changed_files": 1
+  },
+  "label": {
+    "id": 742557442,
+    "url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/labels/release",
+    "name": "release",
+    "color": "bfc7fc",
+    "default": false
+  },
+  "repository": {
+    "id": 109757823,
+    "name": "probot-playground",
+    "full_name": "KevinGrandon/probot-playground",
+    "owner": {
+      "login": "KevinGrandon",
+      "id": 122602,
+      "avatar_url": "https://avatars0.githubusercontent.com/u/122602?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/KevinGrandon",
+      "html_url": "https://github.com/KevinGrandon",
+      "followers_url": "https://api.github.com/users/KevinGrandon/followers",
+      "following_url":
+        "https://api.github.com/users/KevinGrandon/following{/other_user}",
+      "gists_url": "https://api.github.com/users/KevinGrandon/gists{/gist_id}",
+      "starred_url":
+        "https://api.github.com/users/KevinGrandon/starred{/owner}{/repo}",
+      "subscriptions_url":
+        "https://api.github.com/users/KevinGrandon/subscriptions",
+      "organizations_url": "https://api.github.com/users/KevinGrandon/orgs",
+      "repos_url": "https://api.github.com/users/KevinGrandon/repos",
+      "events_url":
+        "https://api.github.com/users/KevinGrandon/events{/privacy}",
+      "received_events_url":
+        "https://api.github.com/users/KevinGrandon/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "private": false,
+    "html_url": "https://github.com/KevinGrandon/probot-playground",
+    "description": "Test repo to play /w probot.",
+    "fork": false,
+    "url": "https://api.github.com/repos/KevinGrandon/probot-playground",
+    "forks_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/forks",
+    "keys_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/keys{/key_id}",
+    "collaborators_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/collaborators{/collaborator}",
+    "teams_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/teams",
+    "hooks_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/hooks",
+    "issue_events_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/issues/events{/number}",
+    "events_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/events",
+    "assignees_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/assignees{/user}",
+    "branches_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/branches{/branch}",
+    "tags_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/tags",
+    "blobs_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/git/blobs{/sha}",
+    "git_tags_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/git/tags{/sha}",
+    "git_refs_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/git/refs{/sha}",
+    "trees_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/git/trees{/sha}",
+    "statuses_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/statuses/{sha}",
+    "languages_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/languages",
+    "stargazers_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/stargazers",
+    "contributors_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/contributors",
+    "subscribers_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/subscribers",
+    "subscription_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/subscription",
+    "commits_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/commits{/sha}",
+    "git_commits_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/git/commits{/sha}",
+    "comments_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/comments{/number}",
+    "issue_comment_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/issues/comments{/number}",
+    "contents_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/contents/{+path}",
+    "compare_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/compare/{base}...{head}",
+    "merges_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/merges",
+    "archive_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/{archive_format}{/ref}",
+    "downloads_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/downloads",
+    "issues_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/issues{/number}",
+    "pulls_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/pulls{/number}",
+    "milestones_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/milestones{/number}",
+    "notifications_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/notifications{?since,all,participating}",
+    "labels_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/labels{/name}",
+    "releases_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/releases{/id}",
+    "deployments_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/deployments",
+    "created_at": "2017-11-06T22:32:54Z",
+    "updated_at": "2017-11-06T22:32:54Z",
+    "pushed_at": "2018-02-23T20:24:21Z",
+    "git_url": "git://github.com/KevinGrandon/probot-playground.git",
+    "ssh_url": "git@github.com:KevinGrandon/probot-playground.git",
+    "clone_url": "https://github.com/KevinGrandon/probot-playground.git",
+    "svn_url": "https://github.com/KevinGrandon/probot-playground",
+    "homepage": null,
+    "size": 5,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": null,
+    "has_issues": true,
+    "has_projects": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": false,
+    "forks_count": 0,
+    "mirror_url": null,
+    "archived": false,
+    "open_issues_count": 2,
+    "license": null,
+    "forks": 0,
+    "open_issues": 2,
+    "watchers": 0,
+    "default_branch": "master"
+  },
+  "sender": {
+    "login": "kevin-test-probot[bot]",
+    "id": 33334198,
+    "avatar_url": "https://avatars0.githubusercontent.com/u/122602?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/kevin-test-probot%5Bbot%5D",
+    "html_url": "https://github.com/apps/kevin-test-probot",
+    "followers_url":
+      "https://api.github.com/users/kevin-test-probot%5Bbot%5D/followers",
+    "following_url":
+      "https://api.github.com/users/kevin-test-probot%5Bbot%5D/following{/other_user}",
+    "gists_url":
+      "https://api.github.com/users/kevin-test-probot%5Bbot%5D/gists{/gist_id}",
+    "starred_url":
+      "https://api.github.com/users/kevin-test-probot%5Bbot%5D/starred{/owner}{/repo}",
+    "subscriptions_url":
+      "https://api.github.com/users/kevin-test-probot%5Bbot%5D/subscriptions",
+    "organizations_url":
+      "https://api.github.com/users/kevin-test-probot%5Bbot%5D/orgs",
+    "repos_url":
+      "https://api.github.com/users/kevin-test-probot%5Bbot%5D/repos",
+    "events_url":
+      "https://api.github.com/users/kevin-test-probot%5Bbot%5D/events{/privacy}",
+    "received_events_url":
+      "https://api.github.com/users/kevin-test-probot%5Bbot%5D/received_events",
+    "type": "Bot",
+    "site_admin": false
+  },
+  "installation": {
+    "id": 65422
+  }
+}


### PR DESCRIPTION
* Set status to pending when running a verification build.
* Set status to successful for pre-release builds, but still kick them off for information.
* Send additional metadata to Buildkite release pipeline.

Related PR: https://github.com/uber-workflow/fusion-release/pull/32

Refs #72