### PR TITLE
Set probot/release-verification status context to block on relase verification

### DIFF
--- a/src/__tests__/fixtures/non-release-opened-payload.json
+++ b/src/__tests__/fixtures/non-release-opened-payload.json
@@ -1,0 +1,597 @@
+{
+  "action": "opened",
+  "number": 7,
+  "pull_request": {
+    "url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/7",
+    "id": 182012652,
+    "html_url": "https://github.com/KevinGrandon/probot-playground/pull/7",
+    "diff_url": "https://github.com/KevinGrandon/probot-playground/pull/7.diff",
+    "patch_url":
+      "https://github.com/KevinGrandon/probot-playground/pull/7.patch",
+    "issue_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/issues/7",
+    "number": 7,
+    "state": "open",
+    "locked": false,
+    "title": "Test",
+    "user": {
+      "login": "KevinGrandon",
+      "id": 122602,
+      "avatar_url": "https://avatars0.githubusercontent.com/u/122602?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/KevinGrandon",
+      "html_url": "https://github.com/KevinGrandon",
+      "followers_url": "https://api.github.com/users/KevinGrandon/followers",
+      "following_url":
+        "https://api.github.com/users/KevinGrandon/following{/other_user}",
+      "gists_url": "https://api.github.com/users/KevinGrandon/gists{/gist_id}",
+      "starred_url":
+        "https://api.github.com/users/KevinGrandon/starred{/owner}{/repo}",
+      "subscriptions_url":
+        "https://api.github.com/users/KevinGrandon/subscriptions",
+      "organizations_url": "https://api.github.com/users/KevinGrandon/orgs",
+      "repos_url": "https://api.github.com/users/KevinGrandon/repos",
+      "events_url":
+        "https://api.github.com/users/KevinGrandon/events{/privacy}",
+      "received_events_url":
+        "https://api.github.com/users/KevinGrandon/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "body": "",
+    "created_at": "2018-04-16T23:15:00Z",
+    "updated_at": "2018-04-16T23:15:00Z",
+    "closed_at": null,
+    "merged_at": null,
+    "merge_commit_sha": null,
+    "assignee": null,
+    "assignees": [],
+    "requested_reviewers": [],
+    "requested_teams": [],
+    "labels": [],
+    "milestone": null,
+    "commits_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/7/commits",
+    "review_comments_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/7/comments",
+    "review_comment_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/comments{/number}",
+    "comments_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/issues/7/comments",
+    "statuses_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/statuses/cc5b2fd8dec120f786e912c68a0857cd90539b65",
+    "head": {
+      "label": "KevinGrandon:test-things",
+      "ref": "test-things",
+      "sha": "cc5b2fd8dec120f786e912c68a0857cd90539b65",
+      "user": {
+        "login": "KevinGrandon",
+        "id": 122602,
+        "avatar_url": "https://avatars0.githubusercontent.com/u/122602?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/KevinGrandon",
+        "html_url": "https://github.com/KevinGrandon",
+        "followers_url": "https://api.github.com/users/KevinGrandon/followers",
+        "following_url":
+          "https://api.github.com/users/KevinGrandon/following{/other_user}",
+        "gists_url":
+          "https://api.github.com/users/KevinGrandon/gists{/gist_id}",
+        "starred_url":
+          "https://api.github.com/users/KevinGrandon/starred{/owner}{/repo}",
+        "subscriptions_url":
+          "https://api.github.com/users/KevinGrandon/subscriptions",
+        "organizations_url": "https://api.github.com/users/KevinGrandon/orgs",
+        "repos_url": "https://api.github.com/users/KevinGrandon/repos",
+        "events_url":
+          "https://api.github.com/users/KevinGrandon/events{/privacy}",
+        "received_events_url":
+          "https://api.github.com/users/KevinGrandon/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "repo": {
+        "id": 109757823,
+        "name": "probot-playground",
+        "full_name": "KevinGrandon/probot-playground",
+        "owner": {
+          "login": "KevinGrandon",
+          "id": 122602,
+          "avatar_url": "https://avatars0.githubusercontent.com/u/122602?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/KevinGrandon",
+          "html_url": "https://github.com/KevinGrandon",
+          "followers_url":
+            "https://api.github.com/users/KevinGrandon/followers",
+          "following_url":
+            "https://api.github.com/users/KevinGrandon/following{/other_user}",
+          "gists_url":
+            "https://api.github.com/users/KevinGrandon/gists{/gist_id}",
+          "starred_url":
+            "https://api.github.com/users/KevinGrandon/starred{/owner}{/repo}",
+          "subscriptions_url":
+            "https://api.github.com/users/KevinGrandon/subscriptions",
+          "organizations_url": "https://api.github.com/users/KevinGrandon/orgs",
+          "repos_url": "https://api.github.com/users/KevinGrandon/repos",
+          "events_url":
+            "https://api.github.com/users/KevinGrandon/events{/privacy}",
+          "received_events_url":
+            "https://api.github.com/users/KevinGrandon/received_events",
+          "type": "User",
+          "site_admin": false
+        },
+        "private": false,
+        "html_url": "https://github.com/KevinGrandon/probot-playground",
+        "description": "Test repo to play /w probot.",
+        "fork": false,
+        "url": "https://api.github.com/repos/KevinGrandon/probot-playground",
+        "forks_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/forks",
+        "keys_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/keys{/key_id}",
+        "collaborators_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/collaborators{/collaborator}",
+        "teams_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/teams",
+        "hooks_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/hooks",
+        "issue_events_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues/events{/number}",
+        "events_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/events",
+        "assignees_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/assignees{/user}",
+        "branches_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/branches{/branch}",
+        "tags_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/tags",
+        "blobs_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/blobs{/sha}",
+        "git_tags_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/tags{/sha}",
+        "git_refs_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/refs{/sha}",
+        "trees_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/trees{/sha}",
+        "statuses_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/statuses/{sha}",
+        "languages_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/languages",
+        "stargazers_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/stargazers",
+        "contributors_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/contributors",
+        "subscribers_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/subscribers",
+        "subscription_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/subscription",
+        "commits_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/commits{/sha}",
+        "git_commits_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/commits{/sha}",
+        "comments_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/comments{/number}",
+        "issue_comment_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues/comments{/number}",
+        "contents_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/contents/{+path}",
+        "compare_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/compare/{base}...{head}",
+        "merges_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/merges",
+        "archive_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/{archive_format}{/ref}",
+        "downloads_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/downloads",
+        "issues_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues{/number}",
+        "pulls_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/pulls{/number}",
+        "milestones_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/milestones{/number}",
+        "notifications_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/notifications{?since,all,participating}",
+        "labels_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/labels{/name}",
+        "releases_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/releases{/id}",
+        "deployments_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/deployments",
+        "created_at": "2017-11-06T22:32:54Z",
+        "updated_at": "2017-11-06T22:32:54Z",
+        "pushed_at": "2018-04-16T23:14:54Z",
+        "git_url": "git://github.com/KevinGrandon/probot-playground.git",
+        "ssh_url": "git@github.com:KevinGrandon/probot-playground.git",
+        "clone_url": "https://github.com/KevinGrandon/probot-playground.git",
+        "svn_url": "https://github.com/KevinGrandon/probot-playground",
+        "homepage": null,
+        "size": 5,
+        "stargazers_count": 0,
+        "watchers_count": 0,
+        "language": null,
+        "has_issues": true,
+        "has_projects": true,
+        "has_downloads": true,
+        "has_wiki": true,
+        "has_pages": false,
+        "forks_count": 0,
+        "mirror_url": null,
+        "archived": false,
+        "open_issues_count": 3,
+        "license": null,
+        "forks": 0,
+        "open_issues": 3,
+        "watchers": 0,
+        "default_branch": "master"
+      }
+    },
+    "base": {
+      "label": "KevinGrandon:master",
+      "ref": "master",
+      "sha": "eaf7120fd50a3805c64fe83ee3b14b2ae48ab517",
+      "user": {
+        "login": "KevinGrandon",
+        "id": 122602,
+        "avatar_url": "https://avatars0.githubusercontent.com/u/122602?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/KevinGrandon",
+        "html_url": "https://github.com/KevinGrandon",
+        "followers_url": "https://api.github.com/users/KevinGrandon/followers",
+        "following_url":
+          "https://api.github.com/users/KevinGrandon/following{/other_user}",
+        "gists_url":
+          "https://api.github.com/users/KevinGrandon/gists{/gist_id}",
+        "starred_url":
+          "https://api.github.com/users/KevinGrandon/starred{/owner}{/repo}",
+        "subscriptions_url":
+          "https://api.github.com/users/KevinGrandon/subscriptions",
+        "organizations_url": "https://api.github.com/users/KevinGrandon/orgs",
+        "repos_url": "https://api.github.com/users/KevinGrandon/repos",
+        "events_url":
+          "https://api.github.com/users/KevinGrandon/events{/privacy}",
+        "received_events_url":
+          "https://api.github.com/users/KevinGrandon/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "repo": {
+        "id": 109757823,
+        "name": "probot-playground",
+        "full_name": "KevinGrandon/probot-playground",
+        "owner": {
+          "login": "KevinGrandon",
+          "id": 122602,
+          "avatar_url": "https://avatars0.githubusercontent.com/u/122602?v=4",
+          "gravatar_id": "",
+          "url": "https://api.github.com/users/KevinGrandon",
+          "html_url": "https://github.com/KevinGrandon",
+          "followers_url":
+            "https://api.github.com/users/KevinGrandon/followers",
+          "following_url":
+            "https://api.github.com/users/KevinGrandon/following{/other_user}",
+          "gists_url":
+            "https://api.github.com/users/KevinGrandon/gists{/gist_id}",
+          "starred_url":
+            "https://api.github.com/users/KevinGrandon/starred{/owner}{/repo}",
+          "subscriptions_url":
+            "https://api.github.com/users/KevinGrandon/subscriptions",
+          "organizations_url": "https://api.github.com/users/KevinGrandon/orgs",
+          "repos_url": "https://api.github.com/users/KevinGrandon/repos",
+          "events_url":
+            "https://api.github.com/users/KevinGrandon/events{/privacy}",
+          "received_events_url":
+            "https://api.github.com/users/KevinGrandon/received_events",
+          "type": "User",
+          "site_admin": false
+        },
+        "private": false,
+        "html_url": "https://github.com/KevinGrandon/probot-playground",
+        "description": "Test repo to play /w probot.",
+        "fork": false,
+        "url": "https://api.github.com/repos/KevinGrandon/probot-playground",
+        "forks_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/forks",
+        "keys_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/keys{/key_id}",
+        "collaborators_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/collaborators{/collaborator}",
+        "teams_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/teams",
+        "hooks_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/hooks",
+        "issue_events_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues/events{/number}",
+        "events_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/events",
+        "assignees_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/assignees{/user}",
+        "branches_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/branches{/branch}",
+        "tags_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/tags",
+        "blobs_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/blobs{/sha}",
+        "git_tags_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/tags{/sha}",
+        "git_refs_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/refs{/sha}",
+        "trees_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/trees{/sha}",
+        "statuses_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/statuses/{sha}",
+        "languages_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/languages",
+        "stargazers_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/stargazers",
+        "contributors_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/contributors",
+        "subscribers_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/subscribers",
+        "subscription_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/subscription",
+        "commits_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/commits{/sha}",
+        "git_commits_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/git/commits{/sha}",
+        "comments_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/comments{/number}",
+        "issue_comment_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues/comments{/number}",
+        "contents_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/contents/{+path}",
+        "compare_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/compare/{base}...{head}",
+        "merges_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/merges",
+        "archive_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/{archive_format}{/ref}",
+        "downloads_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/downloads",
+        "issues_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues{/number}",
+        "pulls_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/pulls{/number}",
+        "milestones_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/milestones{/number}",
+        "notifications_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/notifications{?since,all,participating}",
+        "labels_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/labels{/name}",
+        "releases_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/releases{/id}",
+        "deployments_url":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/deployments",
+        "created_at": "2017-11-06T22:32:54Z",
+        "updated_at": "2017-11-06T22:32:54Z",
+        "pushed_at": "2018-04-16T23:14:54Z",
+        "git_url": "git://github.com/KevinGrandon/probot-playground.git",
+        "ssh_url": "git@github.com:KevinGrandon/probot-playground.git",
+        "clone_url": "https://github.com/KevinGrandon/probot-playground.git",
+        "svn_url": "https://github.com/KevinGrandon/probot-playground",
+        "homepage": null,
+        "size": 5,
+        "stargazers_count": 0,
+        "watchers_count": 0,
+        "language": null,
+        "has_issues": true,
+        "has_projects": true,
+        "has_downloads": true,
+        "has_wiki": true,
+        "has_pages": false,
+        "forks_count": 0,
+        "mirror_url": null,
+        "archived": false,
+        "open_issues_count": 3,
+        "license": null,
+        "forks": 0,
+        "open_issues": 3,
+        "watchers": 0,
+        "default_branch": "master"
+      }
+    },
+    "_links": {
+      "self": {
+        "href":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/7"
+      },
+      "html": {
+        "href": "https://github.com/KevinGrandon/probot-playground/pull/7"
+      },
+      "issue": {
+        "href":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues/7"
+      },
+      "comments": {
+        "href":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/issues/7/comments"
+      },
+      "review_comments": {
+        "href":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/7/comments"
+      },
+      "review_comment": {
+        "href":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/comments{/number}"
+      },
+      "commits": {
+        "href":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/pulls/7/commits"
+      },
+      "statuses": {
+        "href":
+          "https://api.github.com/repos/KevinGrandon/probot-playground/statuses/cc5b2fd8dec120f786e912c68a0857cd90539b65"
+      }
+    },
+    "author_association": "OWNER",
+    "merged": false,
+    "mergeable": null,
+    "rebaseable": null,
+    "mergeable_state": "unknown",
+    "merged_by": null,
+    "comments": 0,
+    "review_comments": 0,
+    "maintainer_can_modify": false,
+    "commits": 1,
+    "additions": 2,
+    "deletions": 0,
+    "changed_files": 1
+  },
+  "repository": {
+    "id": 109757823,
+    "name": "probot-playground",
+    "full_name": "KevinGrandon/probot-playground",
+    "owner": {
+      "login": "KevinGrandon",
+      "id": 122602,
+      "avatar_url": "https://avatars0.githubusercontent.com/u/122602?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/KevinGrandon",
+      "html_url": "https://github.com/KevinGrandon",
+      "followers_url": "https://api.github.com/users/KevinGrandon/followers",
+      "following_url":
+        "https://api.github.com/users/KevinGrandon/following{/other_user}",
+      "gists_url": "https://api.github.com/users/KevinGrandon/gists{/gist_id}",
+      "starred_url":
+        "https://api.github.com/users/KevinGrandon/starred{/owner}{/repo}",
+      "subscriptions_url":
+        "https://api.github.com/users/KevinGrandon/subscriptions",
+      "organizations_url": "https://api.github.com/users/KevinGrandon/orgs",
+      "repos_url": "https://api.github.com/users/KevinGrandon/repos",
+      "events_url":
+        "https://api.github.com/users/KevinGrandon/events{/privacy}",
+      "received_events_url":
+        "https://api.github.com/users/KevinGrandon/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "private": false,
+    "html_url": "https://github.com/KevinGrandon/probot-playground",
+    "description": "Test repo to play /w probot.",
+    "fork": false,
+    "url": "https://api.github.com/repos/KevinGrandon/probot-playground",
+    "forks_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/forks",
+    "keys_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/keys{/key_id}",
+    "collaborators_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/collaborators{/collaborator}",
+    "teams_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/teams",
+    "hooks_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/hooks",
+    "issue_events_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/issues/events{/number}",
+    "events_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/events",
+    "assignees_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/assignees{/user}",
+    "branches_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/branches{/branch}",
+    "tags_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/tags",
+    "blobs_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/git/blobs{/sha}",
+    "git_tags_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/git/tags{/sha}",
+    "git_refs_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/git/refs{/sha}",
+    "trees_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/git/trees{/sha}",
+    "statuses_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/statuses/{sha}",
+    "languages_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/languages",
+    "stargazers_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/stargazers",
+    "contributors_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/contributors",
+    "subscribers_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/subscribers",
+    "subscription_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/subscription",
+    "commits_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/commits{/sha}",
+    "git_commits_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/git/commits{/sha}",
+    "comments_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/comments{/number}",
+    "issue_comment_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/issues/comments{/number}",
+    "contents_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/contents/{+path}",
+    "compare_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/compare/{base}...{head}",
+    "merges_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/merges",
+    "archive_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/{archive_format}{/ref}",
+    "downloads_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/downloads",
+    "issues_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/issues{/number}",
+    "pulls_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/pulls{/number}",
+    "milestones_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/milestones{/number}",
+    "notifications_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/notifications{?since,all,participating}",
+    "labels_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/labels{/name}",
+    "releases_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/releases{/id}",
+    "deployments_url":
+      "https://api.github.com/repos/KevinGrandon/probot-playground/deployments",
+    "created_at": "2017-11-06T22:32:54Z",
+    "updated_at": "2017-11-06T22:32:54Z",
+    "pushed_at": "2018-04-16T23:14:54Z",
+    "git_url": "git://github.com/KevinGrandon/probot-playground.git",
+    "ssh_url": "git@github.com:KevinGrandon/probot-playground.git",
+    "clone_url": "https://github.com/KevinGrandon/probot-playground.git",
+    "svn_url": "https://github.com/KevinGrandon/probot-playground",
+    "homepage": null,
+    "size": 5,
+    "stargazers_count": 0,
+    "watchers_count": 0,
+    "language": null,
+    "has_issues": true,
+    "has_projects": true,
+    "has_downloads": true,
+    "has_wiki": true,
+    "has_pages": false,
+    "forks_count": 0,
+    "mirror_url": null,
+    "archived": false,
+    "open_issues_count": 3,
+    "license": null,
+    "forks": 0,
+    "open_issues": 3,
+    "watchers": 0,
+    "default_branch": "master"
+  },
+  "sender": {
+    "login": "KevinGrandon",
+    "id": 122602,
+    "avatar_url": "https://avatars0.githubusercontent.com/u/122602?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/KevinGrandon",
+    "html_url": "https://github.com/KevinGrandon",
+    "followers_url": "https://api.github.com/users/KevinGrandon/followers",
+    "following_url":
+      "https://api.github.com/users/KevinGrandon/following{/other_user}",
+    "gists_url": "https://api.github.com/users/KevinGrandon/gists{/gist_id}",
+    "starred_url":
+      "https://api.github.com/users/KevinGrandon/starred{/owner}{/repo}",
+    "subscriptions_url":
+      "https://api.github.com/users/KevinGrandon/subscriptions",
+    "organizations_url": "https://api.github.com/users/KevinGrandon/orgs",
+    "repos_url": "https://api.github.com/users/KevinGrandon/repos",
+    "events_url": "https://api.github.com/users/KevinGrandon/events{/privacy}",
+    "received_events_url":
+      "https://api.github.com/users/KevinGrandon/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "installation": {
+    "id": 65422
+  }
+}

--- a/src/__tests__/release-verification.test.js
+++ b/src/__tests__/release-verification.test.js
@@ -2,6 +2,7 @@ import {createRobot} from 'probot';
 import app from '../release-verification';
 
 import nonReleasePayload from './fixtures/non-release-payload.json';
+import nonReleaseOpenedPayload from './fixtures/non-release-opened-payload.json';
 import prereleasePayload from './fixtures/prerelease-payload.json';
 import releasePayload from './fixtures/release-payload.json';
 
@@ -30,6 +31,18 @@ describe('release-verification', () => {
     };
     // Passes the mocked out GitHub API into out robot instance
     robot.auth = () => Promise.resolve(github);
+  });
+
+  it('sets status to success for non-release payload', async () => {
+    await robot.receive({
+      event: 'pull_request',
+      payload: nonReleaseOpenedPayload,
+    });
+    // Should immediately set success
+    const statusCalls = github.repos.createStatus.mock.calls;
+    expect(github.repos.createStatus).toHaveBeenCalled();
+    expect(statusCalls.length).toBe(1);
+    expect(statusCalls[0][0].state).toBe('success');
   });
 
   it('non-release tag applied', async () => {


### PR DESCRIPTION
Currently we only set this status for tagged release PRs. In order to block all fusion repos on release verification we should immediately set this status to passing.

Relevant PR: https://github.com/uber-workflow/fusion-orchestrate/pull/60