### PR TITLE
Replace curl with node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "now-start": "PRIVATE_KEY=$(echo $PRIVATE_KEY | base64 -d) npm start"
   },
   "dependencies": {
+    "node-fetch": "^2.2.0",
     "probot": "7.0.1",
     "probot-app-deploy": "1.0.3",
     "probot-app-label-docs-pr": "1.0.2",
@@ -15,12 +16,12 @@
     "probot-app-license": "1.0.2",
     "probot-app-merge-pr": "1.0.3",
     "probot-app-migrations": "1.0.5",
+    "probot-app-pr-label": "1.0.1",
     "probot-app-pr-title": "^1.1.5",
     "probot-app-release": "1.0.4",
     "probot-app-release-notes": "1.0.6",
     "probot-app-release-pr-compare": "1.0.1",
-    "probot-app-todos": "1.0.5",
-    "probot-app-pr-label": "1.0.1"
+    "probot-app-todos": "1.0.5"
   },
   "probot": {
     "apps": [

--- a/src/release-verification.js
+++ b/src/release-verification.js
@@ -49,6 +49,20 @@ module.exports = robot => {
     }
 
     const prerelease = isPrerelease(pr.title);
+
+    // Ignore verification run for prereleases
+    if (prerelease) {
+      setStatus(context, {
+        state: 'success',
+        description: 'Verification run for prerelease not required.',
+      });
+    } else {
+      setStatus(context, {
+        state: 'pending',
+        description: 'Waiting for verification run to finish.',
+      });
+    }
+
     const payload = {
       commit: 'HEAD',
       branch: 'master',
@@ -89,19 +103,6 @@ module.exports = robot => {
         body: `Triggered Fusion.js build verification: ${output.web_url}`,
       }),
     );
-
-    // Ignore verification run for prereleases
-    if (prerelease) {
-      setStatus(context, {
-        state: 'success',
-        description: 'Verification run for prerelease not required.',
-      });
-    } else {
-      setStatus(context, {
-        state: 'pending',
-        description: 'Waiting for verification run to finish.',
-      });
-    }
   }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3811,6 +3811,10 @@ node-fetch@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.1.tgz#369ca70b82f50c86496104a6c776d274f4e4a2d4"
 
+node-fetch@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.2.0.tgz#4ee79bde909262f9775f731e3656d0db55ced5b5"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"


### PR DESCRIPTION
This PR changes the bot to kick off release verification builds with node-fetch rather than spawning a child process with curl.