### PR TITLE
Add auto-approve and land for pre-releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
       "probot-app-release-pr-compare",
       "probot-app-todos",
       "probot-app-pr-label",
-      "./src/release-verification.js"
+      "./src/release-verification.js",
+      "./src/auto-approve-and-land-prereleases.js"
     ]
   },
   "engines": {

--- a/src/__tests__/auto-approve-and-land-prereleases.test.js
+++ b/src/__tests__/auto-approve-and-land-prereleases.test.js
@@ -1,0 +1,81 @@
+import {Application} from 'probot';
+import app from '../auto-approve-and-land-prereleases.js';
+
+import nonReleasePayload from './fixtures/non-release-payload.json';
+import prereleasePayload from './fixtures/prerelease-payload.json';
+
+describe('auto-approve-and-land-prereleases', () => {
+  let robot;
+  let github;
+
+  beforeEach(() => {
+    robot = new Application();
+    robot.load(app);
+    github = {
+      issues: {
+        createComment: jest.fn(),
+      },
+      pullRequests: {
+        createReview: jest.fn(),
+        merge: jest.fn()
+      },
+      orgs: {
+        checkMembership: jest.fn().mockReturnValue(Promise.resolve({ status: 204 }))
+      }
+    };
+    // Passes the mocked out GitHub API into out robot instance
+    robot.auth = () => Promise.resolve(github);
+  });
+
+  it('non-approval for non-release payload', async () => {
+    await robot.receive({
+      event: 'pull_request',
+      payload: nonReleasePayload,
+    });
+
+    // Should silently fail with no approval/merge
+    const createReviewCalls = github.pullRequests.createReview.mock.calls;
+    const mergeCalls = github.pullRequests.merge.mock.calls;
+    expect(createReviewCalls.length).toBe(0);
+    expect(mergeCalls.length).toBe(0);
+  });
+
+  it('approval for pre-release payload', async () => {
+    await robot.receive({
+      event: 'pull_request',
+      payload: prereleasePayload,
+    });
+
+    // Should approve and merge
+    expect(github.pullRequests.createReview).toHaveBeenCalled();
+    expect(github.pullRequests.merge).toHaveBeenCalled();
+  });
+
+  it('non-approval for pre-release payload with invalid user', async () => {
+    github = {
+      issues: {
+        createComment: jest.fn(),
+      },
+      pullRequests: {
+        createReview: jest.fn(),
+        merge: jest.fn()
+      },
+      orgs: {
+        checkMembership: jest.fn().mockReturnValue(Promise.resolve({ status: 404 }))
+      }
+    };
+    // Passes the mocked out GitHub API into out robot instance
+    robot.auth = () => Promise.resolve(github);
+    
+    await robot.receive({
+      event: 'pull_request',
+      payload: prereleasePayload,
+    });
+    
+    // Should silently fail with no approval/merge
+    const createReviewCalls = github.pullRequests.createReview.mock.calls;
+    const mergeCalls = github.pullRequests.merge.mock.calls;
+    expect(createReviewCalls.length).toBe(0);
+    expect(mergeCalls.length).toBe(0);
+  });
+});

--- a/src/auto-approve-and-land-prereleases.js
+++ b/src/auto-approve-and-land-prereleases.js
@@ -1,0 +1,68 @@
+/** Copyright (c) 2017 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = robot => {
+  robot.on('pull_request.opened', handleApproval);
+  robot.on('pull_request.reopened', handleApproval);
+  robot.on('pull_request.edited', handleApproval);
+  robot.on('pull_request.synchronize', handleApproval);
+  robot.on('pull_request.labeled', handleApproval);
+
+  /**
+   * Approves and lands pull requests that match:
+   *    - Is a pre-release
+   *    - Authored by a member of the 'fusionjs' organization on GitHub
+   */
+  async function handleApproval(context) {
+    const {github} = context;
+    const pr = context.payload.pull_request;
+
+    const isPrerelease = getIsPrerelease(pr.title);
+    const isMemberOfFusionOrg = await getIsMemberOfOrg(github, 'fusionjs', pr.user.login);
+    if(!(isPrerelease && isMemberOfFusionOrg)) return;
+
+    // Approve the pull request
+    github.pullRequests.createReview(
+      context.issue({
+        event: "APPROVE"
+      })
+    );
+
+    // Attempt to merge the pull request
+    github.pullRequests.merge(context.issue());
+  }
+};
+
+/* Helper functions */
+
+/*
+ * Gets whether the provided pr title should be considered a pre-release.
+ * 
+ * Note: PR titles should have a dash in it to be considered a prerelease.
+ *   e.g., v1.0.0-alpha1
+ */
+function getIsPrerelease(prTitle) {
+  return /Release v.*\-.*/.test(prTitle);
+}
+
+/*
+ * Gets whether the provided username is a member of the provided organization.
+ */
+async function getIsMemberOfOrg(github, org, username) {
+  try {
+    // Succeeds with a status 204 code, otherwise fails with 404 / 302.
+    //
+    // See docs for more details:
+    //   https://developer.github.com/v3/orgs/members/#check-membership
+    const response = await github.orgs.checkMembership({
+      org: org,
+      username: username
+    });
+    return response.status === 204;
+  } catch (e) {
+    return false;
+  }
+}


### PR DESCRIPTION
Probot that approves and lands pull requests that match:
* Is a pre-release
* Authored by a member of the 'fusionjs' organization on GitHub