### PR TITLE
Add config for replacement bot

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,7 +20,7 @@ steps:
     command: "scripts/deploy.sh"
     concurrency: 1
     concurrency_group: "deploy"
-    branches: master
+    branches: fusion-monorepo-bot
     plugins:
       docker-compose#v2.6.0:
         run: probot-app-workflow

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,7 +3,7 @@
 set -e
 
 yarn global add now@11.0.6
-APP_URL=$(now --npm -t $NOW_TOKEN --public -e PRIVATE_KEY=@github-app-private-key -e APP_ID=@github-app-id -e BUILDKITE_TOKEN=@buildkite-token -e WEBHOOK_SECRET=@github-app-webhook-secret -e NODE_ENV="production")
+APP_URL=$(now --npm -n temporary-probot-app -t $NOW_TOKEN --public -e PRIVATE_KEY=@github-app-private-key -e APP_ID=@github-app-id -e BUILDKITE_TOKEN=@buildkite-token -e WEBHOOK_SECRET=@github-app-webhook-secret -e NODE_ENV="production")
 now scale $APP_URL sfo 1 --token=$NOW_TOKEN
 now alias set $APP_URL fusion-monorepo-probot -t $NOW_TOKEN
 now rm probot-app-workflow --safe -t $NOW_TOKEN -y

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,7 +3,7 @@
 set -e
 
 yarn global add now@11.0.6
-APP_URL=$(now --npm -t $NOW_TOKEN --public -e PRIVATE_KEY=@private-key -e APP_ID=@app-id -e BUILDKITE_TOKEN=@buildkite-token -e WEBHOOK_SECRET=@webhook-secret -e NODE_ENV="production")
+APP_URL=$(now --npm -t $NOW_TOKEN --public -e PRIVATE_KEY=@github-app-private-key -e APP_ID=@github-app-id -e BUILDKITE_TOKEN=@buildkite-token -e WEBHOOK_SECRET=@github-app-webhook-secret -e NODE_ENV="production")
 now scale $APP_URL sfo 1 --token=$NOW_TOKEN
-now alias set $APP_URL fusion-probot -t $NOW_TOKEN
+now alias set $APP_URL fusion-monorepo-probot -t $NOW_TOKEN
 now rm probot-app-workflow --safe -t $NOW_TOKEN -y


### PR DESCRIPTION
I've set up a new bot under the fusionjs org ([fusion-monorepo-bot](https://github.com/organizations/fusionjs/settings/apps/fusion-monorepo-bot)), and will be using the `fusion-monorepo-bot` branch to deploy to that app and stage various monorepo bot updates.

Once we're ready to use the monorepo, we'll switch over to using the new bot, which involves:

- rename the new bot to `fusion-bot`
- switch the buildkite pipeline back to building on `master` branch
- merge `fusion-monorepo-bot` into `master`