### PR TITLE
Remove TODOs bot

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "probot-app-merge-pr": "^1.1.2-0",
     "probot-app-migrations": "^1.0.6-1",
     "probot-app-monorepo-sync": "^0.0.1-5",
-    "probot-app-pr-title": "^1.1.8-1",
-    "probot-app-todos": "^1.0.6-0"
+    "probot-app-pr-title": "^1.1.8-1"
   },
   "probot": {
     "apps": [
@@ -27,8 +26,7 @@
       "probot-app-merge-pr",
       "probot-app-migrations",
       "probot-app-monorepo-sync",
-      "probot-app-pr-title",
-      "probot-app-todos"
+      "probot-app-pr-title"
     ]
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4076,13 +4076,6 @@ probot-app-pr-title@^1.1.8-1:
     compromise "11.5.3"
     probot "^9.2.10"
 
-probot-app-todos@^1.0.6-0:
-  version "1.0.6-0"
-  resolved "https://registry.yarnpkg.com/probot-app-todos/-/probot-app-todos-1.0.6-0.tgz#62e45bf2e659b97dd804b5bb56ef8c720470761f"
-  integrity sha512-jWw/owrhZ/1TpGPtUF8kBYo0E3eYD/EKYXnhTfJOJM39AkxS2lWHEJZowpjl9fBlaE0hjID7lTgQ92oFh93QPQ==
-  dependencies:
-    probot "^9.2.10"
-
 probot@^9.2.10:
   version "9.2.10"
   resolved "https://registry.yarnpkg.com/probot/-/probot-9.2.10.tgz#1bc7659f13656e190565ba02bd58a86d26ae4f11"


### PR DESCRIPTION
This doesn't play well with monorepo syncing. For the time being, we should remove this.