### PR TITLE
Add repo whitelist to webhooks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,10 @@ services:
     environment:
       - NOW_TOKEN
       - NOW_TEAM
-      - ORG_LIST
       - GH_TOKEN
       - BUILDKITE
       - BUILDKITE_REPO
       - BUILDKITE_BRANCH
       - BUILDKITE_PULL_REQUEST
       - REPO_RELATIONSHIPS
+      - REPO_WHITELIST

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "start": "probot run",
+    "start": "node ./wrapped-probot-run.js",
     "test": "echo 'no tests to run'",
     "now-start": "PRIVATE_KEY=$(echo $PRIVATE_KEY | base64 -d) npm start"
   },
   "dependencies": {
+    "body-parser": "^1.19.0",
+    "express": "^4.16.2",
+    "just-safe-get": "^1.3.0",
     "node-fetch": "^2.2.0",
     "probot": "^9.2.10",
     "probot-app-delete-merged-branch": "^1.0.2-0",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,17 +2,12 @@
 
 set -e
 
-orgs=(`echo $ORG_LIST`)
 team=$NOW_TEAM
 token=$NOW_TOKEN
+org="fusionjs"
+app_name="$org-bot"
 
-yarn global add now@11.0.6
-# we use private github apps for this bot, which can't be installed on
-# multiple orgs, so we need a separate deployment for each org
-for org in "${orgs[@]}"; do
-  app_name="$org-bot"
-  app_url=$(now --npm --name=$app_name -T $team -t $token --public -e PRIVATE_KEY="@probot-$org-private-key" -e APP_ID="@probot-$org-app-id" -e WEBHOOK_SECRET="@probot-$org-webhook-secret" -e BUILDKITE_TOKEN=@buildkite-token -e GH_TOKEN="$GH_TOKEN" -e REPO_RELATIONSHIPS="$REPO_RELATIONSHIPS" -e NODE_ENV="production")
-  now scale $app_url sfo 1 -T $team --token=$token
-  now alias set $app_url $app_name -T $team -t $token
-  now rm $app_name --safe -T $team -t $token -y || true
-done
+app_url=$(now --npm --name=$app_name -T $team -t $token --public -e PRIVATE_KEY="@probot-$org-private-key" -e APP_ID="@probot-$org-app-id" -e WEBHOOK_SECRET="@probot-$org-webhook-secret" -e BUILDKITE_TOKEN=@buildkite-token -e GH_TOKEN="$GH_TOKEN" -e REPO_RELATIONSHIPS="$REPO_RELATIONSHIPS"-e REPO_WHITELIST="$REPO_WHITELIST"  -e NODE_ENV="production")
+now scale $app_url sfo 1 -T $team --token=$token
+now alias set $app_url $app_name -T $team -t $token
+now rm $app_name --safe -T $team -t $token -y || true

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,6 +7,7 @@ token=$NOW_TOKEN
 org="fusionjs"
 app_name="$org-bot"
 
+yarn global add now@11.0.6
 app_url=$(now --npm --name=$app_name -T $team -t $token --public -e PRIVATE_KEY="@probot-$org-private-key" -e APP_ID="@probot-$org-app-id" -e WEBHOOK_SECRET="@probot-$org-webhook-secret" -e BUILDKITE_TOKEN=@buildkite-token -e GH_TOKEN="$GH_TOKEN" -e REPO_RELATIONSHIPS="$REPO_RELATIONSHIPS"-e REPO_WHITELIST="$REPO_WHITELIST"  -e NODE_ENV="production")
 now scale $app_url sfo 1 -T $team --token=$token
 now alias set $app_url $app_name -T $team -t $token

--- a/wrapped-probot-run.js
+++ b/wrapped-probot-run.js
@@ -9,7 +9,9 @@ const express = require('express');
 const get = require('just-safe-get');
 const {Probot} = require('probot');
 
-const WHITELIST = new Set(process.env.REPO_WHITELIST || []);
+const WHITELIST = new Set(
+  (process.env.REPO_WHITELIST || '').split(/, ?/)
+);
 
 // this behaves exactly like the `probot run` command, except it
 // wraps the internal probot server so it can intercept webhooks

--- a/wrapped-probot-run.js
+++ b/wrapped-probot-run.js
@@ -36,6 +36,7 @@ Probot.run(process.argv)
       next();
     });
 
+    // ref: https://github.com/probot/probot/blob/ade14ae/src/index.ts#L208
     probot.httpServer.close();
     server.use(probot.server);
     probot.httpServer = server.listen(probot.options.port);

--- a/wrapped-probot-run.js
+++ b/wrapped-probot-run.js
@@ -1,0 +1,41 @@
+/** Copyright (c) 2019 Uber Technologies, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const bodyParser = require('body-parser');
+const express = require('express');
+const get = require('just-safe-get');
+const {Probot} = require('probot');
+
+const WHITELIST = new Set(process.env.REPO_WHITELIST || []);
+
+// this behaves exactly like the `probot run` command, except it
+// wraps the internal probot server so it can intercept webhooks
+// from non-whitelisted repos and prevent them from being handled
+// by our bots
+Probot.run(process.argv)
+  .then(probot => {
+    const server = express();
+
+    server.use(bodyParser.json());
+    server.use((req, res, next) => {
+      if (req.method === 'POST') {
+        const repoName = get(req.body, 'repository.full_name');
+
+        if (repoName && !WHITELIST.has(repoName)) {
+          // non-whitelisted repo tried to send webhook; ignore it
+          res.json({});
+          return;
+        }
+      }
+
+      next();
+    });
+
+    probot.httpServer.close();
+    server.use(probot.server);
+    probot.httpServer = server.listen(probot.options.port);
+  })
+  .catch(console.error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -968,6 +968,22 @@ body-parser@1.18.3:
     raw-body "2.3.3"
     type-is "~1.6.16"
 
+body-parser@^1.19.0:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
+  integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
+  dependencies:
+    bytes "3.1.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    on-finished "~2.3.0"
+    qs "6.7.0"
+    raw-body "2.4.0"
+    type-is "~1.6.17"
+
 bottleneck@^2.15.3:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.17.1.tgz#a45809e4cdf5326e14dc69970f4af7029e22c0f4"
@@ -1078,6 +1094,11 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
+
+bytes@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
+  integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -2215,6 +2236,17 @@ http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
     inherits "2.0.3"
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
+
+http-errors@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
+  integrity sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.1"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -3396,6 +3428,11 @@ micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+mime-db@1.40.0:
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
+  integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
+
 mime-db@~1.38.0:
   version "1.38.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
@@ -3407,6 +3444,13 @@ mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.19:
   integrity sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==
   dependencies:
     mime-db "~1.38.0"
+
+mime-types@~2.1.24:
+  version "2.1.24"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
+  integrity sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==
+  dependencies:
+    mime-db "1.40.0"
 
 mime@1.4.1:
   version "1.4.1"
@@ -4160,7 +4204,7 @@ qs@6.5.2, qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-qs@^6.5.1, qs@^6.5.2:
+qs@6.7.0, qs@^6.5.1, qs@^6.5.2:
   version "6.7.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
@@ -4203,6 +4247,16 @@ raw-body@2.3.3:
     bytes "3.0.0"
     http-errors "1.6.3"
     iconv-lite "0.4.23"
+    unpipe "1.0.0"
+
+raw-body@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.0.tgz#a1ce6fb9c9bc356ca52e89256ab59059e13d0332"
+  integrity sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==
+  dependencies:
+    bytes "3.1.0"
+    http-errors "1.7.2"
+    iconv-lite "0.4.24"
     unpipe "1.0.0"
 
 rc@^1.2.7:
@@ -4568,6 +4622,11 @@ setprototypeof@1.1.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
   integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
 
+setprototypeof@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
+  integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -4758,7 +4817,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.4.0 < 2":
+"statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
@@ -4957,6 +5016,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+toidentifier@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
+  integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
 tough-cookie@^2.3.3, tough-cookie@^2.3.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
@@ -5016,6 +5080,14 @@ type-is@~1.6.16:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.18"
+
+type-is@~1.6.17:
+  version "1.6.18"
+  resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
+  integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
+  dependencies:
+    media-typer "0.3.0"
+    mime-types "~2.1.24"
 
 uglify-js@^3.1.4:
   version "3.5.3"


### PR DESCRIPTION
Follow up to https://github.com/fusionjs/probot-app-workflow/pull/140. This actually solves the original problem of having external users installing our public app. By tapping into the probot express server, this prevents webhooks from non-whitelisted repos from ever making it to probot.

This will allow us to switch back to having one single deployment for our fusion bot